### PR TITLE
fix: align _voteScale with the CRISP producer's encoding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@ broadcast/*
 broadcast/*/31337/
 
 node_modules 
+# Local env backups (contain PRIVATE_KEY / API keys)
+.env.bak*
+.env.*.bak

--- a/src/CrispVoting.sol
+++ b/src/CrispVoting.sol
@@ -482,14 +482,29 @@ contract CrispVoting is PluginUUPSUpgradeable, ProposalUpgradeable, ICrispVoting
     }
 
     /// @notice The factor by which each voter's power is divided before being submitted to CRISP.
-    /// @dev Vote weights must fit inside the CRISP plaintext vote vector, so the client divides each
-    /// voter's token power by `10 ** (decimals / 2)` before voting. The recorded tally is therefore in
-    /// these scaled units, and the quorum check scales `totalVotes` back up by the same factor so it is
-    /// comparable to the raw token supply. This MUST stay in sync with the client-side scaling.
+    /// @dev Vote weights must fit inside the CRISP plaintext vote vector, so the producer keeps ONE
+    /// decimal of precision — `balance / 10 ** (decimals - 1)` — before encrypting. The recorded
+    /// tally is therefore in those units, and the quorum check scales `totalVotes` back up by the
+    /// same factor to compare like with like against the raw token supply.
+    ///
+    /// This MUST stay in sync with the producer. The authority is the CRISP SDK's `getScaledBalance`:
+    ///     const precision = decimals > 1n ? decimals - 1n : 0n;
+    ///     return balance / 10n ** precision;
+    ///
+    /// It previously returned `10 ** (decimals / 2)`, which for an 18-decimal token is 10**9 against
+    /// the producer's 10**17 — understating turnout by 10**8, and so making any non-zero
+    /// `minParticipation` effectively unreachable.
+    ///
+    /// `decimals()` is not part of `IVotesUpgradeable` and the setup accepts bare IVotes tokens, so a
+    /// missing `decimals()` must not brick `hasSucceeded`/`canExecute`/`execute` after install: those
+    /// tokens, and 0/1-decimal tokens, are treated as unscaled.
     /// @return The scaling factor applied to vote weights.
     function _voteScale() internal view returns (uint256) {
-        uint8 tokenDecimals = IERC20MetadataUpgradeable(address(votingToken)).decimals();
-        return 10 ** (uint256(tokenDecimals) / 2);
+        try IERC20MetadataUpgradeable(address(votingToken)).decimals() returns (uint8 tokenDecimals) {
+            return tokenDecimals > 1 ? 10 ** (uint256(tokenDecimals) - 1) : 1;
+        } catch {
+            return 1;
+        }
     }
 
     /// @notice Whether a proposal is signaling-only (a poll) and therefore cannot be executed.

--- a/test/crispVoteScale.t.sol
+++ b/test/crispVoteScale.t.sol
@@ -1,0 +1,166 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+pragma solidity ^0.8.29;
+
+import {Test} from "forge-std/Test.sol";
+
+import {DAO} from "@aragon/osx/core/dao/DAO.sol";
+import {IDAO} from "@aragon/osx-commons-contracts/src/dao/IDAO.sol";
+import {ProxyLib} from "@aragon/osx-commons-contracts/src/utils/deployment/ProxyLib.sol";
+
+import {CrispVoting} from "../src/CrispVoting.sol";
+import {ICrispVoting} from "../src/ICrispVoting.sol";
+import {IInterfold} from "../src/IInterfold.sol";
+
+/// @dev IVotes-shaped token with configurable `decimals()`.
+contract MockTokenWithDecimals {
+    uint8 private immutable _dec;
+
+    constructor(uint8 d) {
+        _dec = d;
+    }
+
+    function decimals() external view returns (uint8) {
+        return _dec;
+    }
+
+    function balanceOf(address) external pure returns (uint256) {
+        return 0;
+    }
+
+    function getPastTotalSupply(uint256) external pure returns (uint256) {
+        return 0;
+    }
+
+    function getVotes(address) external pure returns (uint256) {
+        return 0;
+    }
+
+    function getPastVotes(address, uint256) external pure returns (uint256) {
+        return 0;
+    }
+}
+
+/// @dev Bare IVotes token: no `decimals()` at all. `IVotesUpgradeable` does not declare it, and
+///      `CrispVotingSetup` accepts such tokens directly, so the plugin must tolerate this.
+contract MockTokenNoDecimals {
+    function balanceOf(address) external pure returns (uint256) {
+        return 0;
+    }
+
+    function getPastTotalSupply(uint256) external pure returns (uint256) {
+        return 0;
+    }
+
+    function getVotes(address) external pure returns (uint256) {
+        return 0;
+    }
+
+    function getPastVotes(address, uint256) external pure returns (uint256) {
+        return 0;
+    }
+}
+
+contract MockInterfoldMinimal {
+    function feeToken() external view returns (address) {
+        return address(this);
+    }
+
+    function approve(address, uint256) external pure returns (bool) {
+        return true;
+    }
+}
+
+/// @dev Exposes the internal scale so the cross-boundary rule can be asserted directly.
+contract CrispVotingHarness is CrispVoting {
+    function voteScale() external view returns (uint256) {
+        return _voteScale();
+    }
+}
+
+/// @notice Pins `_voteScale()` to the CRISP producer's encoding.
+///
+///         This is a THREE-WAY SYNC between this contract, the CRISP server, and the client SDK.
+///         The authority is the SDK's `getScaledBalance`:
+///
+///             const precision = decimals > 1n ? decimals - 1n : 0n;
+///             return balance / 10n ** precision;
+///
+///         The tally comes back in those units and the quorum check multiplies it back up, so if
+///         this drifts from the SDK, quorum silently mis-measures turnout — there is no revert and
+///         no visible symptom until a vote fails to reach a quorum it should have reached.
+contract CrispVoteScaleTest is Test {
+    DAO internal dao;
+    MockInterfoldMinimal internal interfold;
+
+    function setUp() public {
+        dao = DAO(
+            payable(ProxyLib.deployUUPSProxy(
+                    address(new DAO()), abi.encodeCall(DAO.initialize, (bytes(""), address(this), address(0), ""))
+                ))
+        );
+        interfold = new MockInterfoldMinimal();
+    }
+
+    function _deploy(address token) internal returns (CrispVotingHarness h) {
+        h = CrispVotingHarness(
+            ProxyLib.deployUUPSProxy(
+                address(new CrispVotingHarness()),
+                abi.encodeCall(
+                    CrispVoting.initialize,
+                    ICrispVoting.PluginInitParams({
+                        dao: IDAO(address(dao)),
+                        token: token,
+                        interfold: address(interfold),
+                        committeeSize: IInterfold.CommitteeSize(0),
+                        paramSet: 0,
+                        crispProgramAddress: address(0xC0FFEE),
+                        computeProviderParams: bytes(""),
+                        votingSettings: ICrispVoting.VotingSettings({
+                            minProposerVotingPower: 0, minParticipation: 0, minDuration: 3600
+                        })
+                    })
+                )
+            )
+        );
+    }
+
+    /// @dev The SDK's rule, transcribed. Any change here must be a change in the SDK first.
+    function _sdkScale(uint8 decimals) internal pure returns (uint256) {
+        return decimals > 1 ? 10 ** (uint256(decimals) - 1) : 1;
+    }
+
+    function test_voteScaleMatchesTheSdkEncoding() public {
+        uint8[5] memory cases = [uint8(2), 6, 8, 18, 24];
+        for (uint256 i = 0; i < cases.length; i++) {
+            CrispVotingHarness h = _deploy(address(new MockTokenWithDecimals(cases[i])));
+            assertEq(h.voteScale(), _sdkScale(cases[i]), "scale must equal 10**(decimals-1)");
+        }
+    }
+
+    /// @dev The specific regression: 10**(decimals/2) gave 10**9 for an 18-decimal token where the
+    ///      producer uses 10**17 — a 10**8 understatement of turnout.
+    function test_voteScaleIsNotTheOldHalfDecimalsFormula() public {
+        CrispVotingHarness h = _deploy(address(new MockTokenWithDecimals(18)));
+        assertEq(h.voteScale(), 1e17, "18-decimal token must scale by 10**17");
+        assertTrue(h.voteScale() != 10 ** (uint256(18) / 2), "must not regress to 10**(decimals/2)");
+    }
+
+    /// @dev 0/1-decimal tokens are unscaled, matching the SDK's `precision = 0` branch.
+    function test_lowDecimalTokensAreUnscaled() public {
+        assertEq(_deploy(address(new MockTokenWithDecimals(0))).voteScale(), 1, "0 decimals: unscaled");
+        assertEq(_deploy(address(new MockTokenWithDecimals(1))).voteScale(), 1, "1 decimal: unscaled");
+    }
+
+    /// @dev A bare IVotes token has no `decimals()`. Reverting here would brick `hasSucceeded`,
+    ///      `canExecute` and `execute` for the whole plugin, unrecoverably, after install.
+    function test_tokenWithoutDecimalsFallsBackToUnscaledInsteadOfReverting() public {
+        assertEq(_deploy(address(new MockTokenNoDecimals())).voteScale(), 1, "missing decimals(): unscaled");
+    }
+
+    function testFuzz_voteScaleMatchesTheSdkForAnyRealisticDecimals(uint8 decimals) public {
+        // 10**77 is the largest power of ten in uint256, so decimals-1 <= 77.
+        decimals = uint8(bound(uint256(decimals), 0, 78));
+        CrispVotingHarness h = _deploy(address(new MockTokenWithDecimals(decimals)));
+        assertEq(h.voteScale(), _sdkScale(decimals), "scale must track the SDK for any decimals");
+    }
+}


### PR DESCRIPTION
_voteScale() returned 10**(decimals/2). The producer keeps one decimal of precision, 10**(decimals-1). For an 18-decimal token that is 10**9 against the producer's 10**17, so the quorum check scaled the tally back up by 10**8 too little and understated turnout by the same factor — making any non-zero minParticipation effectively unreachable. There is no revert and no visible symptom; a vote simply fails to reach a quorum it should have reached.

The authority is the CRISP SDK's getScaledBalance:

    const precision = decimals > 1n ? decimals - 1n : 0n;
    return balance / 10n ** precision;

Also stop reverting for tokens without decimals(). It is not part of IVotesUpgradeable and CrispVotingSetup accepts bare IVotes tokens directly, so an unguarded decimals() call bricks hasSucceeded/canExecute/execute for the whole plugin, after install, unrecoverably. Such tokens — and 0/1-decimal tokens, matching the SDK's precision = 0 branch — are treated as unscaled.

Adds test/crispVoteScale.t.sol, which transcribes the SDK rule and asserts the contract against it, including a fuzz case over all realistic decimals and an explicit guard against regressing to the old formula. Mutation-checked: restoring 10**(decimals/2) fails three of the five tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved voting compatibility with tokens using different decimal configurations.
  * Prevented voting status checks and execution from failing when a token does not provide decimal information.
  * Updated vote scaling to align with CRISP SDK behavior, including support for low-decimal tokens.

* **Tests**
  * Added comprehensive coverage for standard, low-decimal, missing-decimal, regression, and fuzzed voting scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->