### PR TITLE
chore: update to timestamp

### DIFF
--- a/src/CrispVoting.sol
+++ b/src/CrispVoting.sol
@@ -8,6 +8,7 @@ import {
     ProposalUpgradeable
 } from "@aragon/osx-commons-contracts/src/plugin/extensions/proposal/ProposalUpgradeable.sol";
 import {IVotesUpgradeable} from "@openzeppelin/contracts-upgradeable/governance/utils/IVotesUpgradeable.sol";
+import {IERC6372Upgradeable} from "@openzeppelin/contracts-upgradeable/interfaces/IERC6372Upgradeable.sol";
 import {
     IERC20MetadataUpgradeable
 } from "@openzeppelin/contracts-upgradeable/token/ERC20/extensions/IERC20MetadataUpgradeable.sol";
@@ -146,33 +147,8 @@ contract CrispVoting is PluginUUPSUpgradeable, ProposalUpgradeable, ICrispVoting
             (uint256 _allowFailureMap, uint256 numOptions, uint256 creditMode, uint256 credits) =
                 abi.decode(_data, (uint256, uint256, uint256, uint256));
 
-            if (numOptions < 2) {
-                revert InvalidOptionCount(numOptions);
-            }
-
-            /// @notice The exact tuple `CRISPProgram.validate` decodes — all six fields are
-            /// required, and it reverts on a short encoding.
-            /// The census is always TOKEN: the electorate is whoever holds `votingToken` at the
-            /// snapshot, which the coordinator enumerates. BY_REQUESTER would need this plugin to
-            /// expose `getCensus(uint256) returns (address[])` — it has no membership roster to
-            /// answer that with.
-            bytes memory customParams = abi.encode(
-                address(votingToken),
-                votingSettings.minProposerVotingPower,
-                numOptions,
-                ICRISP.CreditMode(creditMode),
-                credits,
-                ICRISP.CensusMode.TOKEN
-            );
-
-            IInterfold.E3RequestParams memory requestParams = IInterfold.E3RequestParams({
-                committeeSize: committeeSize,
-                inputWindow: [uint256(_startDate), uint256(_endDate)],
-                e3Program: IE3Program(crispProgramAddress),
-                computeProviderParams: computeProviderParams,
-                customParams: customParams,
-                paramSet: paramSet
-            });
+            IInterfold.E3RequestParams memory requestParams =
+                _buildRequestParams(_startDate, _endDate, numOptions, creditMode, credits);
 
             // calculate the E3 fee
             uint256 fee = interfold.getE3Quote(requestParams);
@@ -191,8 +167,11 @@ contract CrispVoting is PluginUUPSUpgradeable, ProposalUpgradeable, ICrispVoting
                 numOptions: numOptions,
                 startDate: _startDate,
                 endDate: _endDate,
-                // snapshot the previous block so voting power is read from a finalized block
-                snapshotBlock: block.number - 1,
+                // Snapshot one tick before now, so voting power is read from a finalized
+                // timepoint. This is `_tokenClock()`, NOT `block.number`: the units must be
+                // the voting token's ERC-6372 clock or every `getPastVotes` /
+                // `getPastTotalSupply` read against this value is meaningless.
+                snapshotBlock: _tokenClock() - 1,
                 minVotingPower: votingSettings.minProposerVotingPower,
                 minParticipation: votingSettings.minParticipation,
                 creditMode: ICRISP.CreditMode(creditMode)
@@ -391,6 +370,64 @@ contract CrispVoting is PluginUUPSUpgradeable, ProposalUpgradeable, ICrispVoting
         );
     }
 
+    /// @inheritdoc ICrispVoting
+    function quoteFee(uint64 _startDate, uint64 _endDate, bytes calldata _data)
+        external
+        view
+        returns (uint256 fee)
+    {
+        (uint64 startDate, uint64 endDate) = _validateProposalDates(_startDate, _endDate);
+        (, uint256 numOptions, uint256 creditMode, uint256 credits) =
+            abi.decode(_data, (uint256, uint256, uint256, uint256));
+
+        fee = interfold.getE3Quote(_buildRequestParams(startDate, endDate, numOptions, creditMode, credits));
+    }
+
+    /// @notice Builds the Interfold request for a proposal's parameters.
+    /// @dev Shared by `createProposal` and `quoteFee` so a quote can never drift from the fee
+    /// creation actually charges — a second copy of this encoding would be a silent way for the
+    /// two to disagree.
+    /// @param _startDate The validated proposal start date.
+    /// @param _endDate The validated proposal end date.
+    /// @param _numOptions The number of ballot options.
+    /// @param _creditMode The `ICRISP.CreditMode` to run the round under.
+    /// @param _credits The credits allocated per voter.
+    function _buildRequestParams(
+        uint64 _startDate,
+        uint64 _endDate,
+        uint256 _numOptions,
+        uint256 _creditMode,
+        uint256 _credits
+    ) internal view returns (IInterfold.E3RequestParams memory) {
+        if (_numOptions < 2) {
+            revert InvalidOptionCount(_numOptions);
+        }
+
+        /// @notice The exact tuple `CRISPProgram.validate` decodes — all six fields are
+        /// required, and it reverts on a short encoding.
+        /// The census is always TOKEN: the electorate is whoever holds `votingToken` at the
+        /// snapshot, which the coordinator enumerates. BY_REQUESTER would need this plugin to
+        /// expose `getCensus(uint256) returns (address[])` — it has no membership roster to
+        /// answer that with.
+        bytes memory customParams = abi.encode(
+            address(votingToken),
+            votingSettings.minProposerVotingPower,
+            _numOptions,
+            ICRISP.CreditMode(_creditMode),
+            _credits,
+            ICRISP.CensusMode.TOKEN
+        );
+
+        return IInterfold.E3RequestParams({
+            committeeSize: committeeSize,
+            inputWindow: [uint256(_startDate), uint256(_endDate)],
+            e3Program: IE3Program(crispProgramAddress),
+            computeProviderParams: computeProviderParams,
+            customParams: customParams,
+            paramSet: paramSet
+        });
+    }
+
     /// @notice Validates and returns the proposal vote dates, enforcing the minimum duration.
     /// @param _start The start date of the proposal vote. If 0, the current timestamp is used
     /// and the vote starts immediately.
@@ -511,6 +548,26 @@ contract CrispVoting is PluginUUPSUpgradeable, ProposalUpgradeable, ICrispVoting
             return tokenDecimals > 1 ? 10 ** (uint256(tokenDecimals) - 1) : 1;
         } catch {
             return 1;
+        }
+    }
+
+    /// @notice The current timepoint in the voting token's ERC-6372 clock units.
+    /// @dev `snapshotBlock` is fed straight to `getPastVotes` / `getPastTotalSupply`, so it MUST be
+    /// expressed in whatever clock the token keeps its checkpoints in. This previously recorded
+    /// `block.number - 1`, which is only correct for the OZ default clock. Against a token with
+    /// `CLOCK_MODE=timestamp` a block number is a timepoint decades in the past: the lookup does
+    /// not revert, it returns 0 — so every holder reads as having no voting power, the whole DAO
+    /// looks ineligible, and `_canExecute` bails on `_totalVotingPower == 0`, making every proposal
+    /// permanently unexecutable.
+    ///
+    /// Tokens predating ERC-6372 have no `clock()`; the setup also accepts bare IVotes tokens. Both
+    /// fall back to `block.number`, which is what OZ's own default `clock()` returns.
+    /// @return The current timepoint, in the token's clock units.
+    function _tokenClock() internal view returns (uint256) {
+        try IERC6372Upgradeable(address(votingToken)).clock() returns (uint48 timepoint) {
+            return timepoint;
+        } catch {
+            return block.number;
         }
     }
 

--- a/src/CrispVoting.sol
+++ b/src/CrispVoting.sol
@@ -371,11 +371,7 @@ contract CrispVoting is PluginUUPSUpgradeable, ProposalUpgradeable, ICrispVoting
     }
 
     /// @inheritdoc ICrispVoting
-    function quoteFee(uint64 _startDate, uint64 _endDate, bytes calldata _data)
-        external
-        view
-        returns (uint256 fee)
-    {
+    function quoteFee(uint64 _startDate, uint64 _endDate, bytes calldata _data) external view returns (uint256 fee) {
         (uint64 startDate, uint64 endDate) = _validateProposalDates(_startDate, _endDate);
         (, uint256 numOptions, uint256 creditMode, uint256 credits) =
             abi.decode(_data, (uint256, uint256, uint256, uint256));

--- a/src/ICrispVoting.sol
+++ b/src/ICrispVoting.sol
@@ -162,10 +162,7 @@ interface ICrispVoting {
     /// @param _data The same ABI-encoded `(allowFailureMap, numOptions, creditMode, credits)` that
     /// would be passed to `createProposal`.
     /// @return fee The E3 fee, denominated in the Interfold fee token.
-    function quoteFee(uint64 _startDate, uint64 _endDate, bytes calldata _data)
-        external
-        view
-        returns (uint256 fee);
+    function quoteFee(uint64 _startDate, uint64 _endDate, bytes calldata _data) external view returns (uint256 fee);
 
     /// @notice Returns the minimum voting power needed to propose a vote.
     /// @return The minimum voting power needed to propose a vote.

--- a/src/ICrispVoting.sol
+++ b/src/ICrispVoting.sol
@@ -88,7 +88,10 @@ interface ICrispVoting {
     /// @param numOptions The number of options for the vote.
     /// @param startDate The start date of the proposal vote.
     /// @param endDate The end date of the proposal vote.
-    /// @param snapshotBlock The number of the block prior to the proposal creation.
+    /// @param snapshotBlock The timepoint the voting power census is taken at, one tick before
+    ///        proposal creation, in the voting token's ERC-6372 clock units — a block number for
+    ///        the OZ default clock, a UNIX timestamp for a `CLOCK_MODE=timestamp` token. Named
+    ///        `snapshotBlock` for compatibility with Aragon's TokenVoting parameters.
     /// @param minVotingPower The minimum voting power needed.
     /// @param minParticipation The minimum participation needed.
     /// @param creditMode The credit mode for the vote. CONSTANT proposals are signaling-only.
@@ -143,6 +146,26 @@ interface ICrispVoting {
         IPlugin.TargetConfig targetConfig;
         uint256 e3Id;
     }
+
+    /// @notice Quotes the Interfold E3 fee a proposal with these parameters would cost.
+    /// @dev Takes the same dates and encoded data as `createProposal` and runs them through the
+    /// same request construction, so a caller can escrow exactly the right credit before creating
+    /// rather than discovering the price from a reverted transaction. Reverts identically to
+    /// `createProposal` on invalid dates or option counts.
+    ///
+    /// The quote is only as stable as its inputs: passing `0` for a date normalises it to
+    /// `block.timestamp`, so the window — and therefore the fee — shifts between the quote and the
+    /// transaction that uses it. Pass explicit dates for a figure that will still hold when the
+    /// proposal is created.
+    /// @param _startDate The proposal start date, or 0 for `block.timestamp`.
+    /// @param _endDate The proposal end date, or 0 for the earliest date `minDuration` allows.
+    /// @param _data The same ABI-encoded `(allowFailureMap, numOptions, creditMode, credits)` that
+    /// would be passed to `createProposal`.
+    /// @return fee The E3 fee, denominated in the Interfold fee token.
+    function quoteFee(uint64 _startDate, uint64 _endDate, bytes calldata _data)
+        external
+        view
+        returns (uint256 fee);
 
     /// @notice Returns the minimum voting power needed to propose a vote.
     /// @return The minimum voting power needed to propose a vote.

--- a/test/crispFeeEscrow.t.sol
+++ b/test/crispFeeEscrow.t.sol
@@ -81,13 +81,20 @@ contract MockInterfold {
         return feeTokenAddr;
     }
 
-    function getE3Quote(IInterfold.E3RequestParams calldata) external view returns (uint256) {
-        return quote;
+    /// @dev Priced off the request so a quote that was built from different parameters than the
+    /// request produces a different number. A flat price would let `quoteFee` and `createProposal`
+    /// disagree about the window or the ballot and still look identical in tests.
+    function _price(IInterfold.E3RequestParams calldata p) internal view returns (uint256) {
+        return quote + (p.inputWindow[1] - p.inputWindow[0]) + p.customParams.length;
+    }
+
+    function getE3Quote(IInterfold.E3RequestParams calldata p) external view returns (uint256) {
+        return _price(p);
     }
 
     /// @dev Must match IInterfold.request exactly — it returns (uint256, E3), not (uint256, bytes).
-    function request(IInterfold.E3RequestParams calldata) external returns (uint256, E3 memory e3) {
-        MockFeeToken(feeTokenAddr).transferFrom(msg.sender, address(this), quote);
+    function request(IInterfold.E3RequestParams calldata p) external returns (uint256, E3 memory e3) {
+        MockFeeToken(feeTokenAddr).transferFrom(msg.sender, address(this), _price(p));
         return (1, e3);
     }
 }
@@ -184,6 +191,21 @@ contract CrispFeeEscrowTest is Test {
         return abi.encode(uint256(0), uint256(3), uint256(1), uint256(0));
     }
 
+    function _start() internal view returns (uint64) {
+        return uint64(block.timestamp) + 1;
+    }
+
+    function _end() internal view returns (uint64) {
+        return uint64(block.timestamp) + 3600;
+    }
+
+    /// @dev The fee these tests expect to be charged. Asserting against `quoteFee` rather than a
+    /// literal is the point: if the quote were built from different parameters than the request,
+    /// the priced mock would return a different number and every expectation below would break.
+    function _quote() internal view returns (uint256) {
+        return plugin.quoteFee(_start(), _end(), _data());
+    }
+
     // --- escrow basics ---
 
     function test_depositAndWithdraw() public {
@@ -215,10 +237,12 @@ contract CrispFeeEscrowTest is Test {
         spp.setCreator(7, alice);
         votingToken.setVotes(address(spp), 0); // the SPP has no voting power, and needs none
 
-        vm.prank(address(spp));
-        spp.createOn(address(plugin), 7, uint64(block.timestamp + 1), uint64(block.timestamp + 3600), _data());
+        uint256 fee = _quote();
 
-        assertEq(plugin.feeCredits(alice), 40e6, "the parent creator's credit paid the fee");
+        vm.prank(address(spp));
+        spp.createOn(address(plugin), 7, _start(), _end(), _data());
+
+        assertEq(plugin.feeCredits(alice), 50e6 - fee, "the parent creator's credit paid the fee");
         assertEq(feeToken.balanceOf(address(spp)), 0, "the SPP never needed tokens");
     }
 
@@ -226,8 +250,8 @@ contract CrispFeeEscrowTest is Test {
     function test_sppProposalRevertsWhenTheCreatorHasNoCredit() public {
         spp.setCreator(7, alice); // alice never deposited
 
-        vm.expectRevert(abi.encodeWithSelector(ICrispVoting.InsufficientFeeCredit.selector, alice, 10e6, 0));
-        spp.createOn(address(plugin), 7, uint64(block.timestamp + 1), uint64(block.timestamp + 3600), _data());
+        vm.expectRevert(abi.encodeWithSelector(ICrispVoting.InsufficientFeeCredit.selector, alice, _quote(), 0));
+        spp.createOn(address(plugin), 7, _start(), _end(), _data());
     }
 
     // --- the attack the attestation prevents ---
@@ -243,11 +267,13 @@ contract CrispFeeEscrowTest is Test {
         // Mallory calls directly, pretending to be a sub-proposal of alice's SPP proposal.
         bytes memory forged = abi.encode(address(spp), uint256(7), uint16(0));
 
+        // Read the quote BEFORE the prank: `vm.prank` applies to the next call, and a `quoteFee`
+        // in the expectRevert arguments would swallow it.
+        uint256 fee = _quote();
+
         vm.prank(mallory);
-        vm.expectRevert(abi.encodeWithSelector(ICrispVoting.InsufficientFeeCredit.selector, mallory, 10e6, 0));
-        plugin.createProposal(
-            forged, new Action[](0), uint64(block.timestamp + 1), uint64(block.timestamp + 3600), _data()
-        );
+        vm.expectRevert(abi.encodeWithSelector(ICrispVoting.InsufficientFeeCredit.selector, mallory, fee, 0));
+        plugin.createProposal(forged, new Action[](0), _start(), _end(), _data());
 
         assertEq(plugin.feeCredits(alice), 50e6, "alice's credit must be untouched");
     }
@@ -258,12 +284,12 @@ contract CrispFeeEscrowTest is Test {
         _fund(alice, 50e6);
         votingToken.setVotes(alice, 1);
 
-        vm.prank(alice);
-        plugin.createProposal(
-            bytes("ipfs://x"), new Action[](0), uint64(block.timestamp + 1), uint64(block.timestamp + 3600), _data()
-        );
+        uint256 fee = _quote();
 
-        assertEq(plugin.feeCredits(alice), 40e6, "the direct caller pays from their own escrow");
+        vm.prank(alice);
+        plugin.createProposal(bytes("ipfs://x"), new Action[](0), _start(), _end(), _data());
+
+        assertEq(plugin.feeCredits(alice), 50e6 - fee, "the direct caller pays from their own escrow");
     }
 
     function test_directProposalStillEnforcesProposerVotingPower() public {
@@ -272,8 +298,6 @@ contract CrispFeeEscrowTest is Test {
 
         vm.prank(mallory);
         vm.expectRevert(abi.encodeWithSelector(ICrispVoting.ProposalCreationForbidden.selector, mallory));
-        plugin.createProposal(
-            bytes("ipfs://x"), new Action[](0), uint64(block.timestamp + 1), uint64(block.timestamp + 3600), _data()
-        );
+        plugin.createProposal(bytes("ipfs://x"), new Action[](0), _start(), _end(), _data());
     }
 }

--- a/test/crispTokenClock.t.sol
+++ b/test/crispTokenClock.t.sol
@@ -1,0 +1,235 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+pragma solidity ^0.8.29;
+
+import {Test} from "forge-std/Test.sol";
+
+import {DAO} from "@aragon/osx/core/dao/DAO.sol";
+import {IDAO} from "@aragon/osx-commons-contracts/src/dao/IDAO.sol";
+import {ProxyLib} from "@aragon/osx-commons-contracts/src/utils/deployment/ProxyLib.sol";
+
+import {CrispVoting} from "../src/CrispVoting.sol";
+import {ICrispVoting} from "../src/ICrispVoting.sol";
+import {IInterfold} from "../src/IInterfold.sol";
+
+/// @dev IVotes token on the OZ default clock: checkpoints are keyed by block number.
+contract MockBlockClockToken {
+    function clock() external view returns (uint48) {
+        return uint48(block.number);
+    }
+
+    function CLOCK_MODE() external pure returns (string memory) {
+        return "mode=blocknumber&from=default";
+    }
+
+    function decimals() external pure returns (uint8) {
+        return 18;
+    }
+
+    function balanceOf(address) external pure returns (uint256) {
+        return 0;
+    }
+
+    /// @dev Mirrors OZ: a timepoint at or after `clock()` is a future lookup and reverts;
+    ///      anything before the first checkpoint reads as zero rather than reverting.
+    function getPastTotalSupply(uint256 timepoint) external view returns (uint256) {
+        require(timepoint < block.number, "future lookup");
+        return 1_000e18;
+    }
+
+    function getVotes(address) external pure returns (uint256) {
+        return 0;
+    }
+
+    function getPastVotes(address, uint256 timepoint) external view returns (uint256) {
+        require(timepoint < block.number, "future lookup");
+        return 100e18;
+    }
+}
+
+/// @dev IVotes token with `CLOCK_MODE=timestamp` (OZ `VotesTimestamp`). This is the shape the
+///      deployed governance token actually has, and the one the old `block.number - 1` snapshot
+///      silently broke: a block number is far below any real timestamp, so it is a valid *past*
+///      lookup that returns zero instead of reverting.
+contract MockTimestampClockToken {
+    /// @dev First checkpoint. Reads before this are genuinely zero.
+    uint256 public immutable deployedAt;
+
+    constructor() {
+        deployedAt = block.timestamp;
+    }
+
+    function clock() external view returns (uint48) {
+        return uint48(block.timestamp);
+    }
+
+    function CLOCK_MODE() external pure returns (string memory) {
+        return "mode=timestamp";
+    }
+
+    function decimals() external pure returns (uint8) {
+        return 18;
+    }
+
+    function balanceOf(address) external pure returns (uint256) {
+        return 0;
+    }
+
+    function getPastTotalSupply(uint256 timepoint) external view returns (uint256) {
+        require(timepoint < block.timestamp, "future lookup");
+        return timepoint < deployedAt ? 0 : 1_000e18;
+    }
+
+    function getVotes(address) external pure returns (uint256) {
+        return 0;
+    }
+
+    function getPastVotes(address, uint256 timepoint) external view returns (uint256) {
+        require(timepoint < block.timestamp, "future lookup");
+        return timepoint < deployedAt ? 0 : 100e18;
+    }
+}
+
+/// @dev Predates ERC-6372: no `clock()`. `IVotesUpgradeable` does not declare one and
+///      `CrispVotingSetup` accepts such tokens, so the plugin must not revert on them.
+contract MockNoClockToken {
+    function decimals() external pure returns (uint8) {
+        return 18;
+    }
+
+    function balanceOf(address) external pure returns (uint256) {
+        return 0;
+    }
+
+    function getPastTotalSupply(uint256) external pure returns (uint256) {
+        return 1_000e18;
+    }
+
+    function getVotes(address) external pure returns (uint256) {
+        return 0;
+    }
+
+    function getPastVotes(address, uint256) external pure returns (uint256) {
+        return 100e18;
+    }
+}
+
+contract MockInterfoldMinimal {
+    function feeToken() external view returns (address) {
+        return address(this);
+    }
+
+    function approve(address, uint256) external pure returns (bool) {
+        return true;
+    }
+}
+
+/// @dev Exposes the internal clock so the snapshot units can be asserted without creating a
+///      proposal (which would need a live Interfold to issue an e3Id).
+contract CrispVotingClockHarness is CrispVoting {
+    function tokenClock() external view returns (uint256) {
+        return _tokenClock();
+    }
+}
+
+/// @notice Pins `snapshotBlock` to the voting token's ERC-6372 clock.
+///
+///         `snapshotBlock` is passed straight to `getPastVotes` / `getPastTotalSupply`, so it has
+///         to be in the units the token keeps its checkpoints in. The failure mode when it is not
+///         is uniquely nasty: against a `CLOCK_MODE=timestamp` token a block number is a valid
+///         *past* timepoint, so nothing reverts — every holder just reads as having zero voting
+///         power, the census looks empty, and `_canExecute` bails on `_totalVotingPower == 0`,
+///         making every proposal permanently unexecutable.
+contract CrispTokenClockTest is Test {
+    DAO internal dao;
+    MockInterfoldMinimal internal interfold;
+
+    function setUp() public {
+        // Push both clocks well clear of zero so a block number and a timestamp cannot coincide.
+        vm.roll(11_500_000);
+        vm.warp(1_786_700_000);
+
+        dao = DAO(
+            payable(ProxyLib.deployUUPSProxy(
+                    address(new DAO()), abi.encodeCall(DAO.initialize, (bytes(""), address(this), address(0), ""))
+                ))
+        );
+        interfold = new MockInterfoldMinimal();
+    }
+
+    function _deploy(address token) internal returns (CrispVotingClockHarness h) {
+        h = CrispVotingClockHarness(
+            ProxyLib.deployUUPSProxy(
+                address(new CrispVotingClockHarness()),
+                abi.encodeCall(
+                    CrispVoting.initialize,
+                    ICrispVoting.PluginInitParams({
+                        dao: IDAO(address(dao)),
+                        token: token,
+                        interfold: address(interfold),
+                        committeeSize: IInterfold.CommitteeSize(0),
+                        paramSet: 0,
+                        crispProgramAddress: address(0xC0FFEE),
+                        computeProviderParams: bytes(""),
+                        votingSettings: ICrispVoting.VotingSettings({
+                            minProposerVotingPower: 0, minParticipation: 0, minDuration: 3600
+                        })
+                    })
+                )
+            )
+        );
+    }
+
+    function test_timestampClockedTokenSnapshotsInTimestamps() public {
+        CrispVotingClockHarness h = _deploy(address(new MockTimestampClockToken()));
+        assertEq(h.tokenClock(), block.timestamp, "must follow the token's timestamp clock");
+        assertTrue(h.tokenClock() != block.number, "must not fall back to the block number");
+    }
+
+    function test_blockClockedTokenSnapshotsInBlockNumbers() public {
+        CrispVotingClockHarness h = _deploy(address(new MockBlockClockToken()));
+        assertEq(h.tokenClock(), block.number, "must follow the token's block-number clock");
+    }
+
+    /// @dev A bare IVotes token has no `clock()`; `block.number` is what OZ's own default returns.
+    function test_tokenWithoutClockFallsBackToBlockNumberInsteadOfReverting() public {
+        CrispVotingClockHarness h = _deploy(address(new MockNoClockToken()));
+        assertEq(h.tokenClock(), block.number, "missing clock(): fall back to block.number");
+    }
+
+    /// @dev The regression itself. `snapshotBlock = block.number - 1` against a timestamp-clocked
+    ///      token does not revert — it reads zero, which is why this shipped unnoticed.
+    function test_blockNumberSnapshotSilentlyReadsZeroOnATimestampClockedToken() public {
+        MockTimestampClockToken token = new MockTimestampClockToken();
+        // Move past the mock's first checkpoint so a correctly-derived snapshot reads non-zero;
+        // otherwise both branches read zero and the test proves nothing.
+        vm.warp(block.timestamp + 1);
+
+        assertEq(token.getPastVotes(address(this), block.number - 1), 0, "block number reads as no voting power");
+        assertEq(token.getPastTotalSupply(block.number - 1), 0, "block number reads as no total supply");
+
+        CrispVotingClockHarness h = _deploy(address(token));
+        uint256 snapshot = h.tokenClock() - 1;
+
+        assertEq(token.getPastVotes(address(this), snapshot), 100e18, "clock-derived snapshot reads real power");
+        assertEq(token.getPastTotalSupply(snapshot), 1_000e18, "clock-derived snapshot reads real supply");
+    }
+
+    /// @dev `_tokenClock() - 1` must always be a readable past timepoint, never a future lookup.
+    function testFuzz_snapshotIsAlwaysAReadablePastTimepoint(uint32 blocksAhead, uint32 secondsAhead) public {
+        vm.roll(block.number + bound(uint256(blocksAhead), 1, 1_000_000));
+        vm.warp(block.timestamp + bound(uint256(secondsAhead), 1, 1_000_000));
+
+        MockTimestampClockToken tsToken = new MockTimestampClockToken();
+        MockBlockClockToken blockToken = new MockBlockClockToken();
+
+        // Move past the mock's own first checkpoint so a correct read is non-zero.
+        vm.warp(block.timestamp + 1);
+        vm.roll(block.number + 1);
+
+        uint256 tsSnapshot = _deploy(address(tsToken)).tokenClock() - 1;
+        assertEq(tsToken.getPastVotes(address(this), tsSnapshot), 100e18, "timestamp snapshot must be readable");
+
+        uint256 blockSnapshot = _deploy(address(blockToken)).tokenClock() - 1;
+        assertEq(blockToken.getPastVotes(address(this), blockSnapshot), 100e18, "block snapshot must be readable");
+    }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added fee quotes for proposals based on their dates and encoded data.
  * Proposal snapshots now support token-defined ERC-6372 clocks, with block-number fallback.
  * Updated proposal fee calculations to provide more accurate estimates.

* **Bug Fixes**
  * Improved compatibility with timestamp-based voting tokens.
  * Prevented invalid snapshot handling for tokens without a supported clock.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->